### PR TITLE
Don't fail when executed from cron or any other thing where TTY is missing

### DIFF
--- a/columnar/columnar.py
+++ b/columnar/columnar.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import re
 import io
 import operator
@@ -20,7 +21,7 @@ class Columnar():
         self.min_column_width = min_column_width
         self.justify = justify
         self.head = head
-        self.terminal_width = os.get_terminal_size().columns
+        self.terminal_width = shutil.get_terminal_size().columns
         self.row_sep = row_sep
         self.column_sep = column_sep
         self.header_sep = '='


### PR DESCRIPTION
Need to create a report from cron and columnar is perfect for the job except that it fails when no terminal exist. To test the failure you can create a small program and then just do something like
   `python3 test.py|cat`
by changing from os to shutil it looks at COLUMNS as an option and then it not only works from cron, it can be run it like
  `COLUMNS=1023 python3 test.py|cat`
