### PR TITLE
Packaging fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 dev/
 *.pyc
 *.ipynb

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Max Taggart
+
+SPDX-License-Identifier: MIT
+-->
+
 # Columnar
 
 A library for creating columnar output strings using data as input.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ data = [
 
 patterns = [
     ('Saturday.+', lambda text: style(text, fg='white', bg='blue')),
-    ('\d+km', lambda text: style(text, fg='cyan')),
+    (r'\d+km', lambda text: style(text, fg='cyan')),
     ('Omloop Het Nieuwsblad', lambda text: style(text, fg='green')),
     ('Strade Bianche', lambda text: style(text, fg='white')),
     ('Milan-San Remo', lambda text: style(text, fg='red')),

--- a/algorithm.md
+++ b/algorithm.md
@@ -1,2 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2019 Max Taggart
+
+SPDX-License-Identifier: MIT
+-->
+
 if the columns do not all fit, calculate the amount that you would need to subtract from the largest column to make the table fit. if this number is less than 2 times the column delimeter, or is smaller than the next widest column, then distribute the amount between the two largest columns, if this makes them less than 3 times the column delimiter or less than the third largest column, distribute the amount between the four largest columns, etc. The end condition is reached when distributing the reduction between columns leads to a table that will fit in the terminal, or the table collapses down to be less than ncolumns + 1 wide, meaning that it would then contain only column delimiters.
 Ideally when a suitable table size is found, the columns would be sized to utiltize the whole width of the screen.

--- a/columnar/__init__.py
+++ b/columnar/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from .columnar import Columnar
 
 columnar = Columnar()

--- a/columnar/columnar.py
+++ b/columnar/columnar.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 import shutil
 import re
 import io

--- a/columnar/exceptions.py
+++ b/columnar/exceptions.py
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 class TableOverflowError(Exception):
     pass

--- a/columnar/images/emojis_and_wide_chars.png.license
+++ b/columnar/images/emojis_and_wide_chars.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 Max Taggart
+
+SPDX-License-Identifier: MIT

--- a/columnar/images/example_no_borders.png.license
+++ b/columnar/images/example_no_borders.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 Max Taggart
+
+SPDX-License-Identifier: MIT

--- a/columnar/images/example_spring_classics.png.license
+++ b/columnar/images/example_spring_classics.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 Max Taggart
+
+SPDX-License-Identifier: MIT

--- a/columnar/test/colors_justifications_headers.py
+++ b/columnar/test/colors_justifications_headers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/drop_dash_and_none_columns.py
+++ b/columnar/test/drop_dash_and_none_columns.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/example.py
+++ b/columnar/test/example.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 
 headers = ["User", "Message", "Zip"]

--- a/columnar/test/lots_of_columns.py
+++ b/columnar/test/lots_of_columns.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/no_borders.py
+++ b/columnar/test/no_borders.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/no_borders_no_headers.py
+++ b/columnar/test/no_borders_no_headers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/no_headers.py
+++ b/columnar/test/no_headers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/select_columns_two_and_five.py
+++ b/columnar/test/select_columns_two_and_five.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/specify_terminal_width.py
+++ b/columnar/test/specify_terminal_width.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 from click import style
 

--- a/columnar/test/wide_characters_and_emojis.py
+++ b/columnar/test/wide_characters_and_emojis.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 from columnar import columnar
 
 headers = ['name', 'id', 'host', 'notes']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+
+# SPDX-License-Identifier: MIT
+
+[metadata]
+name = Columnar
+version = 1.3.1
+description = A tool for printing data in a columnar format.
+long_description = file:README.md
+long_description_content_type = text/markdown
+author = Max Taggart
+author_email = max.taggart@gmail.com
+license_files =
+    LICENSE.text
+    LICENSES/*
+classifiers =
+    Programming Language :: Python :: 3.7
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+packages = find:
+install_requires =
+    toolz
+    wcwidth

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ long_description = file:README.md
 long_description_content_type = text/markdown
 author = Max Taggart
 author_email = max.taggart@gmail.com
+license = MIT
 license_files =
     LICENSE.text
     LICENSES/*
@@ -20,6 +21,7 @@ classifiers =
 
 [options]
 packages = find:
+python_requires = ~= 3.7
 install_requires =
     toolz
     wcwidth

--- a/setup.py
+++ b/setup.py
@@ -4,26 +4,4 @@
 
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="Columnar",
-    version="1.3.1",
-    author="Max Taggart",
-    author_email="max.taggart@gmail.com",
-    description="A tool for printing data in a columnar format.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(),
-    install_requires=[
-        'toolz',
-        'wcwidth',
-    ],
-    classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-)
-
+setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Max Taggart
+#
+# SPDX-License-Identifier: MIT
+
 import setuptools
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
Thank you for your library! I'm looking to use it in a couple of places, so I thought I would send a couple of cleanups on the packaging side.

The SPDX tags are to make it easier to do license validation (see [this blog post of mine](https://flameeyes.blog/2020/04/23/reuse-simplifying-code-licensing/)), and making sure your copyright doesn't get buried behind imports.

The declarative setuptools file makes it easier to read information programmatically, and I found it easier to maintain long term.

If that interests you, I'm also happy to add, or send you a new pull request with, the [pre-commit](https://pre-commit.com/) and GitHub Actions integration to make sure that the project stays REUSE compliant in the future.